### PR TITLE
Fixed segfault and deleted token if var is null

### DIFF
--- a/src/expanser/var.c
+++ b/src/expanser/var.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   var.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: foctavia <foctavia@student.42.fr>          +#+  +:+       +#+        */
+/*   By: owalsh <owalsh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/24 14:58:51 by foctavia          #+#    #+#             */
-/*   Updated: 2022/08/29 17:30:45 by foctavia         ###   ########.fr       */
+/*   Updated: 2022/09/01 16:21:53 by owalsh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,21 @@ static void	check_new(t_token *new)
 	}
 }
 
+void    delete_token(t_token **tokens)
+{
+    t_token    *prev;
+    t_token    *next;
+
+    prev = (*tokens)->prev;
+    next = (*tokens)->next;
+    if (prev)
+        prev->next = next;
+    if (next)
+        next->prev = prev;
+    free((*tokens)->value);
+    free(*tokens);
+}
+
 int	expanse_var(t_token **tokens)
 {
 	t_token	*new;
@@ -37,8 +52,7 @@ int	expanse_var(t_token **tokens)
 	str = getenv(var++);
 	if (!str)
 	{
-		(*tokens)->value = NULL;
-		(*tokens)->type = 0;
+		delete_token(tokens);
 		return (EXIT_SUCCESS);
 	}
 	ms_lexer(str, &new);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: owalsh <owalsh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/22 14:02:04 by owalsh            #+#    #+#             */
-/*   Updated: 2022/09/01 10:56:59 by owalsh           ###   ########.fr       */
+/*   Updated: 2022/09/01 16:09:44 by owalsh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ int	main(int argc, char **argv, char **env)
 			&& !ms_expanser(&data.tokens))
 		{
 			display_tokens();
-			// ms_parser(data.tokens, &data.cmds);
+			ms_parser(data.tokens, &data.cmds);
 			// execution
 		}
 		add_history(data.shell.input);

--- a/src/utils/string.c
+++ b/src/utils/string.c
@@ -6,7 +6,7 @@
 /*   By: owalsh <owalsh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/29 15:18:42 by owalsh            #+#    #+#             */
-/*   Updated: 2022/08/31 16:22:58 by owalsh           ###   ########.fr       */
+/*   Updated: 2022/09/01 16:17:46 by owalsh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,7 @@ char	*ft_sjoin(char *s1, char *s2)
 	int		j;
 	char	*str;
 
-	if ((!s1 && !s2) || !s2[0])
+	if ((!s1 && !s2) || (s2 && !s2[0]))
 		return (NULL);
 	str = malloc(sizeof(char) * (ft_strlen(s1) + ft_strlen(s2) + 1));
 	if (!str)


### PR DESCRIPTION
*
Segfaults cause by ft_sjoin, when s2 is null and we check if s2[0] exists.